### PR TITLE
Fix console log to show correct port 8080:

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,5 +13,5 @@ app.get("/", (req, res) => {
 });
 
 app.listen(8080, () => {
-  console.log("Serving on port 3000");
+  console.log("Serving on port 8080");
 });


### PR DESCRIPTION
This branch changes line 16 of app.js. Before, it showed "console.log("Serving on port 3000");" I changed it to  console.log("Serving on port 8080");" to make it consistent with "app.listen listen(8080, () => {" on line 15. 